### PR TITLE
fix: download artifact beforce publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,10 +7,10 @@ jobs:
   install:
         runs-on: self-hosted
         steps:
-#             - name: 'Download a single artifact'
-#               uses: actions/download-artifact@v3
-#               with:
-#                 name: dist    
+            - name: 'Download a single artifact'
+              uses: actions/download-artifact@v3
+              with:
+                name: dist    
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v2
               with:


### PR DESCRIPTION
The package doesn't have /dist folder after installation